### PR TITLE
Update chirp-executable.yml

### DIFF
--- a/.github/workflows/chirp-executable.yml
+++ b/.github/workflows/chirp-executable.yml
@@ -8,8 +8,8 @@ permissions:
 
 on:
   push:
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+   branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
we had set the executable to be generated on pushes with tags, but we never used tags so deleted this requirement