### PR TITLE
Update chirp-executable.yml

### DIFF
--- a/.github/workflows/chirp-executable.yml
+++ b/.github/workflows/chirp-executable.yml
@@ -64,7 +64,7 @@ jobs:
     
     strategy:
       matrix: 
-        os: [ 'linux-arm64', 'linux-x64', 'osx-arm64', 'osx-x64', 'win-arm64', 'win-x64' ] 
+        os: [ 'linux-arm64', 'linux-x64', 'osx-arm64', 'osx-x64', 'win-x64' ] 
     
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
remove win-arm64 from matrix as it fails